### PR TITLE
Allow setting the username and password separately from the DSN

### DIFF
--- a/pkg/bsql/config.go
+++ b/pkg/bsql/config.go
@@ -16,7 +16,9 @@ type Config struct {
 }
 
 type DatabaseConfig struct {
-	DSN string `yaml:"dsn" json:"dsn"` // DSN connection string
+	DSN      string `yaml:"dsn" json:"dsn"` // DSN connection string
+	User     string `yaml:"user" json:"user"`
+	Password string `yaml:"password" json:"password"`
 }
 
 type ResourceType struct {

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -83,7 +83,7 @@ func New(ctx context.Context, configFilePath string) (*Connector, error) {
 }
 
 func newConnector(ctx context.Context, c *bsql.Config) (*Connector, error) {
-	db, dbEngine, err := database.Connect(ctx, c.Connect.DSN)
+	db, dbEngine, err := database.Connect(ctx, c.Connect.DSN, c.Connect.User, c.Connect.Password)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -68,13 +68,13 @@ func Test_updateDSNFromEnv(t *testing.T) {
 					t.Fatalf("failed to set env var %s: %v", k, err)
 				}
 			}
-			got, err := updateDSNFromEnv(tt.args.ctx, tt.args.dsn)
+			got, err := updateFromEnv(tt.args.ctx, tt.args.dsn)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("updateDSNFromEnv() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("updateFromEnv() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("updateDSNFromEnv() got = %v, want %v", got, tt.want)
+				t.Errorf("updateFromEnv() got = %v, want %v", got, tt.want)
 			}
 			for k := range tt.env {
 				if err := os.Unsetenv(k); err != nil {


### PR DESCRIPTION
When go parses a URI, it ensures that each component has valid encoding. If the username or password includes a character that must be escaped in a URI, then parsing will fail. To work around this, we optionally let users provide the username and password separately, and then we use `url.UserPassword()` to properly encode them before attaching it to the parsed URI. 

If the DSN specifies a username/password it will take priority over other things.