### PR TITLE
Fix action schema response. Use key for name and name for display name.

### DIFF
--- a/pkg/bsql/config.go
+++ b/pkg/bsql/config.go
@@ -423,7 +423,6 @@ type ActionConfig struct {
 
 type ArgumentConfig struct {
 	Name        string `yaml:"name" json:"name" validate:"required"`
-	DisplayName string `yaml:"display_name,omitempty" json:"display_name,omitempty" validate:"omitempty"`
 	Description string `yaml:"description,omitempty" json:"description,omitempty" validate:"omitempty"`
 	//revive:disable-next-line:line-length-limit // because it's a long field
 	Type     string `yaml:"type" json:"type" validate:"required,oneof=string boolean number string_list string_map" jsonschema:"enum=string,enum=boolean,enum=number,enum=string_list,enum=string_map"`

--- a/pkg/connector/action.go
+++ b/pkg/connector/action.go
@@ -57,15 +57,12 @@ func (c *Connector) RegisterActionManager(ctx context.Context) (connectorbuilder
 			ActionType:  convertActionTypes(actionCfg.ActionType),
 		}
 
-		for _, argCfg := range actionCfg.Arguments {
+		for k, argCfg := range actionCfg.Arguments {
 			arg := &config_sdk.Field{
-				Name:        argCfg.Name,
-				DisplayName: argCfg.DisplayName,
+				Name:        k,
+				DisplayName: argCfg.Name,
 				Description: argCfg.Description,
 				IsRequired:  argCfg.Required,
-			}
-			if arg.DisplayName == "" {
-				arg.DisplayName = argCfg.Name
 			}
 			defaultValue := argCfg.Default
 			switch argCfg.Type {
@@ -138,7 +135,7 @@ func (c *Connector) RegisterActionManager(ctx context.Context) (connectorbuilder
 		cfg := actionCfg
 
 		err := actionManager.RegisterAction(ctx, actionKey, actionSchema, func(ctx context.Context, args *structpb.Struct) (*structpb.Struct, annotations.Annotations, error) {
-			return c.handleQueryAction(ctx, cfg, args)
+			return c.handleQueryAction(ctx, actionKey, cfg, args)
 		})
 		if err != nil {
 			l.Error("failed to register action", zap.String("action", actionKey), zap.Error(err))
@@ -150,9 +147,9 @@ func (c *Connector) RegisterActionManager(ctx context.Context) (connectorbuilder
 	return actionManager, nil
 }
 
-func (c *Connector) handleQueryAction(ctx context.Context, actionCfg bsql.ActionConfig, args *structpb.Struct) (*structpb.Struct, annotations.Annotations, error) {
+func (c *Connector) handleQueryAction(ctx context.Context, actionKey string, actionCfg bsql.ActionConfig, args *structpb.Struct) (*structpb.Struct, annotations.Annotations, error) {
 	l := ctxzap.Extract(ctx)
-	l.Debug("actionHandler", zap.String("action", actionCfg.Name))
+	l.Debug("actionHandler", zap.String("action", actionKey))
 
 	sqlSyncer, err := bsql.NewActionSyncer(ctx, c.db, c.dbEngine, c.celEnv, *c.config)
 	if err != nil {
@@ -163,7 +160,7 @@ func (c *Connector) handleQueryAction(ctx context.Context, actionCfg bsql.Action
 	for k, v := range actionCfg.Arguments {
 		if _, ok := args.Fields[k]; !ok {
 			if v.Required {
-				return nil, nil, fmt.Errorf("argument %s is required", v.Name)
+				return nil, nil, fmt.Errorf("argument %s is required", k)
 			}
 			if v.Default != nil {
 				argMap[k] = v.Default
@@ -172,22 +169,22 @@ func (c *Connector) handleQueryAction(ctx context.Context, actionCfg bsql.Action
 		}
 		switch v.Type {
 		case "string":
-			argMap[k] = args.Fields[v.Name].GetStringValue()
+			argMap[k] = args.Fields[k].GetStringValue()
 		case "boolean":
-			argMap[k] = args.Fields[v.Name].GetBoolValue()
+			argMap[k] = args.Fields[k].GetBoolValue()
 		case "number":
-			argMap[k] = args.Fields[v.Name].GetNumberValue()
+			argMap[k] = args.Fields[k].GetNumberValue()
 		case "string_list":
-			values := args.Fields[v.Name].GetListValue().GetValues()
+			values := args.Fields[k].GetListValue().GetValues()
 			var stringList []string
 			for _, value := range values {
 				stringList = append(stringList, value.GetStringValue())
 			}
 			argMap[k] = stringList
 		case "string_map":
-			argMap[k] = args.Fields[v.Name].GetStructValue().AsMap()
+			argMap[k] = args.Fields[k].GetStructValue().AsMap()
 		default:
-			return nil, nil, fmt.Errorf("unsupported argument type: %s", v.Type)
+			return nil, nil, fmt.Errorf("argument %s has unsupported type: %s", k, v.Type)
 		}
 	}
 


### PR DESCRIPTION
#### Description

- [X] Bug fix
- [ ] New feature

#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use argument map keys as names and config `name` as display label; remove `display_name` field; pass and log `actionKey` in handler and read args by key.
> 
> - **Actions**:
>   - **Argument schema**: Use argument map keys as `name` and set `displayName` from `ArgumentConfig.name`; remove fallback logic.
>   - **Handler**: Pass `actionKey` to `handleQueryAction`, update logs to use it, and read argument values by key; improve error messages to reference keys.
> - **Config**:
>   - Remove `ArgumentConfig.display_name` from `pkg/bsql/config.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b26b58ac79334dbac6e08e90cee87fbca6a861ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Argument labels in the UI now consistently use the raw parameter name; the separate custom display label was removed.
  - The previous fallback to a separate label is gone; if no custom label is provided, the parameter name is shown.
  - Internal action identifiers were standardized; visible behavior, types, defaults, and validations remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->