### PR TITLE
SAP HANA: Get group membership working. Get account type working.

### DIFF
--- a/examples/sap-hana-test.yml
+++ b/examples/sap-hana-test.yml
@@ -43,9 +43,10 @@
             user:
               status: .STATUS
               login: .USER_NAME
+              # SYS and any username starting with _SYS is a system user. Everything else is a human user.
+              account_type: 'cel:(cols["USER_NAME"] == "SYS" || string(cols["USER_NAME"]).startsWith("_SYS")) ? "system" : "human"'
               emails:
                 - ".EMAIL_ADDRESS != null ? .EMAIL_ADDRESS : ''"
-              # account_type: ".account_type"
               last_login: ".LAST_SUCCESSFUL_CONNECT != null ? string(.LAST_SUCCESSFUL_CONNECT) : ''"
               created_at: ".CREATE_TIME != null ? string(.CREATE_TIME) : ''"
               profile:
@@ -86,3 +87,33 @@
                 is_client_connect_enabled: .IS_CLIENT_CONNECT_ENABLED
                 has_connect_restriction: .HAS_CONNECT_RESTRICTION
                 comments: ".COMMENTS != null ? .COMMENTS : ''"
+      static_entitlements:
+        - id: "member"
+          display_name: "resource.DisplayName + ' Group Member'"
+          description: "'Member of the ' + resource.DisplayName + ' group'"
+          purpose: "assignment"
+          grantable_to:
+            - "user"
+      grants:
+        - vars:
+            usergroup_id: "resource.ID"
+          query: |
+            SELECT
+              USER_ID,
+              USER_NAME,
+              "SYS"."USERGROUPS".USERGROUP_NAME as USERGROUP_NAME
+            FROM
+              "SYS"."USERGROUPS"
+              LEFT JOIN
+                "SYS"."USERS"
+                ON "SYS"."USERGROUPS".USERGROUP_NAME = "SYS"."USERS".USERGROUP_NAME
+            WHERE "SYS"."USERGROUPS".USERGROUP_ID = ?<usergroup_id>
+            ORDER BY USER_ID
+            LIMIT ?<Limit> OFFSET ?<Offset>
+          pagination:
+            strategy: "offset"
+            primary_key: "USER_ID"
+          map:
+            - principal_id: ".USER_ID"
+              principal_type: "user"
+              entitlement_id: "member"

--- a/pkg/bcel/helpers.go
+++ b/pkg/bcel/helpers.go
@@ -17,6 +17,11 @@ func isAlphaNumeric(c byte) bool {
 // It also detects 'bare strings' and automatically quotes them.
 // Example input: ".role_name == 'Admin'" -> "cols['role_name'] == 'Admin'".
 func preprocessExpressions(expr string) string {
+	if strings.HasPrefix(expr, "cel:") {
+		expr = expr[4:]
+		return expr
+	}
+
 	if bareStringRegexp.MatchString(expr) {
 		if expr == "true" || expr == "false" {
 			return expr


### PR DESCRIPTION
#### Description

- [ ] Bug fix
- [X] New feature

#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)

This also adds a new behavior: If you prefix a mapping with `cel:`, we don't replace dots with `col[...]`. This lets you use things like string.startsWith() and other CEL functions.