### PR TITLE
CXH-1583: Fix inverted role-to-role direction in redshift example

### DIFF
--- a/examples/redshift-test.yml
+++ b/examples/redshift-test.yml
@@ -173,8 +173,8 @@ resource_types:
           SELECT role_name, granted_role_name FROM svv_role_grants
           ORDER BY role_name, granted_role_name
         map:
-          - skip_if: ".role_name != resource.ID"
-            principal_id: ".granted_role_name"
+          - skip_if: ".granted_role_name != resource.ID"
+            principal_id: ".role_name"
             principal_type: role
             entitlement_id: member
 

--- a/pkg/bsql/provisioning_grant_reject_test.go
+++ b/pkg/bsql/provisioning_grant_reject_test.go
@@ -24,7 +24,7 @@ func newGrantProvisioningTestSyncer(t *testing.T) (*SQLSyncer, *sql.DB) {
 		require.NoError(t, db.Close())
 	})
 
-	_, err = db.Exec(`CREATE TABLE user_roles (user_id TEXT PRIMARY KEY, role TEXT)`)
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE user_roles (user_id TEXT PRIMARY KEY, role TEXT)`)
 	require.NoError(t, err)
 
 	env, err := bcel.NewEnv(t.Context())
@@ -68,7 +68,7 @@ func TestRunGrantProvisioning_RejectIfMatchReturnsGrantCancelledAndSkipsMutation
 	require.Equal(t, "Grant cancelled: user already has a mutually exclusive role.", cancelled.Reason)
 
 	var count int
-	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM user_roles`).Scan(&count))
+	require.NoError(t, db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM user_roles`).Scan(&count))
 	require.Equal(t, 0, count)
 }
 
@@ -96,7 +96,7 @@ func TestRunGrantProvisioning_RejectIfNoMatchProceedsWithGrant(t *testing.T) {
 	require.Empty(t, annos)
 
 	var role string
-	require.NoError(t, db.QueryRow(`SELECT role FROM user_roles WHERE user_id = ?`, "user-1").Scan(&role))
+	require.NoError(t, db.QueryRowContext(t.Context(), `SELECT role FROM user_roles WHERE user_id = ?`, "user-1").Scan(&role))
 	require.Equal(t, "admin", role)
 }
 


### PR DESCRIPTION
Redshift role-to-role membership was being synced in the wrong direction; the example config now maps the source view's columns correctly so role hierarchies show the right parent/member relationship.