### PR TITLE
CXH-1584: Surface database-level access in redshift connector

### DIFF
--- a/examples/redshift-test.yml
+++ b/examples/redshift-test.yml
@@ -194,39 +194,41 @@ resource_types:
         display_name: ".database_name"
         description: "'Redshift database ' + string(.database_name)"
     static_entitlements:
-      # Read-only: https://docs.aws.amazon.com/redshift/latest/dg/r_GRANT.html lists CREATE/TEMP/USAGE/ALTER as the
-      # database-level grantable privileges, not CONNECT. svv_database_privileges
-      # still surfaces CONNECT rows, so visibility works, but a GRANT CONNECT path
-      # is not documented and is left out until validated.
-      - id: connect
-        display_name: "resource.DisplayName + ' CONNECT'"
-        description: "'CONNECT on database ' + resource.DisplayName"
+      # Read-only aggregate of database-level privileges (TEMP, USAGE, CREATE) per
+      # https://docs.aws.amazon.com/redshift/latest/dg/r_GRANT.html. svv_database_privileges
+      # never emits CONNECT despite the column name suggesting it; the actual rows are
+      # TEMP, USAGE, and CREATE granted to named principals or PUBLIC. Kept immutable
+      # until per-privilege provisioning is validated against a real cluster.
+      - id: access
+        display_name: "resource.DisplayName + ' access'"
+        description: "'Database-level access (TEMP/USAGE/CREATE) on ' + resource.DisplayName"
         purpose: permission
         grantable_to: [user]
-        slug: connect
+        slug: access
         immutable: true
     grants:
       # svv_database_privileges is per-database, so this query runs once per DB and
       # we filter to the row matching resource.ID. identity_type is 'user' | 'role' |
-      # 'group' | 'public'; one map entry per type, others skipped.
+      # 'group' | 'public'. PUBLIC rows are intentionally skipped here; modeling
+      # PUBLIC requires a synthetic principal and is tracked as a follow-up.
       - query: |
           SELECT database_name, privilege_type, identity_name, identity_type
           FROM svv_database_privileges
-          WHERE privilege_type = 'CONNECT'
+          WHERE privilege_type IN ('TEMP', 'USAGE', 'CREATE')
           ORDER BY identity_name
         map:
           - skip_if: ".database_name != resource.ID || .identity_type != 'user'"
             principal_id: ".identity_name"
             principal_type: user
-            entitlement_id: connect
+            entitlement_id: access
           - skip_if: ".database_name != resource.ID || .identity_type != 'role'"
             principal_id: ".identity_name"
             principal_type: role
-            entitlement_id: connect
+            entitlement_id: access
           - skip_if: ".database_name != resource.ID || .identity_type != 'group'"
             principal_id: ".identity_name"
             principal_type: group
-            entitlement_id: connect
+            entitlement_id: access
 
   schema:
     name: "Schema"

--- a/examples/redshift-test.yml
+++ b/examples/redshift-test.yml
@@ -211,8 +211,11 @@ resource_types:
       # we filter to the row matching resource.ID. identity_type is 'user' | 'role' |
       # 'group' | 'public'. PUBLIC rows are intentionally skipped here; modeling
       # PUBLIC requires a synthetic principal and is tracked as a follow-up.
+      # DISTINCT collapses the up-to-three privilege rows (TEMP, USAGE, CREATE) per
+      # principal into a single row, since all three map to the same `access`
+      # entitlement.
       - query: |
-          SELECT database_name, privilege_type, identity_name, identity_type
+          SELECT DISTINCT identity_name, identity_type, database_name
           FROM svv_database_privileges
           WHERE privilege_type IN ('TEMP', 'USAGE', 'CREATE')
           ORDER BY identity_name

--- a/pkg/bsql/provisioning_grant_reject_test.go
+++ b/pkg/bsql/provisioning_grant_reject_test.go
@@ -24,7 +24,7 @@ func newGrantProvisioningTestSyncer(t *testing.T) (*SQLSyncer, *sql.DB) {
 		require.NoError(t, db.Close())
 	})
 
-	_, err = db.Exec(`CREATE TABLE user_roles (user_id TEXT PRIMARY KEY, role TEXT)`)
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE user_roles (user_id TEXT PRIMARY KEY, role TEXT)`)
 	require.NoError(t, err)
 
 	env, err := bcel.NewEnv(t.Context())
@@ -68,7 +68,7 @@ func TestRunGrantProvisioning_RejectIfMatchReturnsGrantCancelledAndSkipsMutation
 	require.Equal(t, "Grant cancelled: user already has a mutually exclusive role.", cancelled.Reason)
 
 	var count int
-	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM user_roles`).Scan(&count))
+	require.NoError(t, db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM user_roles`).Scan(&count))
 	require.Equal(t, 0, count)
 }
 
@@ -96,7 +96,7 @@ func TestRunGrantProvisioning_RejectIfNoMatchProceedsWithGrant(t *testing.T) {
 	require.Empty(t, annos)
 
 	var role string
-	require.NoError(t, db.QueryRow(`SELECT role FROM user_roles WHERE user_id = ?`, "user-1").Scan(&role))
+	require.NoError(t, db.QueryRowContext(t.Context(), `SELECT role FROM user_roles WHERE user_id = ?`, "user-1").Scan(&role))
 	require.Equal(t, "admin", role)
 }
 


### PR DESCRIPTION
Redshift database-level access now shows up correctly in C1; the connector now reads the privilege types Redshift actually emits (TEMP, USAGE, CREATE) on each database, instead of an alias the underlying view does not use.