### PR TITLE
CXH-1588: fix role-grant expandable to reference principal, not parent role

### DIFF
--- a/examples/redshift-test.yml
+++ b/examples/redshift-test.yml
@@ -177,9 +177,12 @@ resource_types:
             principal_id: ".role_name"
             principal_type: role
             entitlement_id: member
+            # Expansion fans this grant out to the PRINCIPAL's members, so the source
+            # entitlement must reference the principal (role_name = the member role),
+            # not granted_role_name (the parent) — a mismatch aborts the entire sync.
             expandable:
               entitlement_ids:
-                - "'role:' + .granted_role_name + ':member'"
+                - "'role:' + .role_name + ':member'"
               shallow: true
 
   # --- Per-database catalog ---------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes CXH-1588. The `svv_role_grants` expandable in `examples/redshift-test.yml` referenced `.granted_role_name` (the parent role = the grant resource) instead of `.role_name` (the member role = the grant principal). After CXH-1583 swapped the grant direction so the principal is `role_name`, the expandable's source entitlement no longer matched the grant's principal, so baton-sdk rejected the grant (`source entitlement resource id did not match grant principal id`) and the runner aborted the entire full sync.

Because Redshift ships built-in system role grants (`sys:dba <- sys:operator`) in `svv_role_grants`, this aborted the sync on every real cluster out of the box.

## Change

`examples/redshift-test.yml` — the `svv_role_grants` expandable now references `'role:' + .role_name + ':member'` (the principal) instead of `.granted_role_name` (the resource), with a comment explaining the principal requirement.

## Verification

Against a live Redshift Serverless cluster (2026-06-04):
- **Before:** full sync deterministically aborts with the validation error; no `.c1z`.
- **After:** `Sync complete.`, and role-hierarchy expansion materializes — `read_only` inherits `analytics.reporting_data.daily_metrics SELECT` via `reporting`.
- `go build` + `go test ./pkg/bsql/... ./pkg/connector/...` (116 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)